### PR TITLE
Fixes #6; Change padding for menu at the 768-991 responsive breakpoint

### DIFF
--- a/static/css/devopskc.css
+++ b/static/css/devopskc.css
@@ -156,3 +156,9 @@ header {
 body {
     webkit-tap-highlight-color: #3b73a7;
 }
+
+@media (min-width: 768px) {
+    .navbar-nav > li > a {
+        padding: 15px 10px 18px 10px;
+    }
+}


### PR DESCRIPTION
Fixes the menu breaking the logo/links on different lines.

![devops-responsive-menu-fix](https://user-images.githubusercontent.com/25877/39668105-3c804160-508a-11e8-8f54-5d5b1b513765.gif)
